### PR TITLE
Improve commenter

### DIFF
--- a/comment.py
+++ b/comment.py
@@ -28,15 +28,8 @@ def comment(comment_to_make):
 
     print "commenting on {0}".format(comment_to_make)
     #from pdb import set_trace; set_trace()
-    prs = g.get_repo(org + "/" + project).get_issues()
 
-
-    pr_object = None
-
-    for particular_pr in prs:
-        if particular_pr.number == int(pr):
-            pr_object = particular_pr
-            break
+    pr_object = g.get_repo(org + "/" + project).get_issue(pr)
 
     response_string = """\
 The result of the test was: {0}

--- a/comment.py
+++ b/comment.py
@@ -38,13 +38,13 @@ def comment(comment_to_make):
             pr_object = particular_pr
             break
 
-    response_string = """
-    The result of the test was: {0}
-    Details at {1}/{2}
+    response_string = """\
+The result of the test was: {0}
+Details at {1}{2}
 
-    I am a beta ci bot. I am probably lying to you.
-    You can contact nibalizer for more details
-    """.format(success, config.rooturl, comment_to_make)
+I am a beta ci bot. I am probably lying to you.
+You can contact nibalizer for more details."""\
+        .format(success, config.rooturl, comment_to_make)
 
     pr_object.create_comment(response_string)
 


### PR DESCRIPTION
This fixes the comments so that they won't be interpreted as code by GitHub's markdown parser, removes a duplicate slash from the generated URL, and directly fetches the desired pull request instead of querying all of them.