### PR TITLE
Add example config, use github tokens

### DIFF
--- a/example_config.py
+++ b/example_config.py
@@ -1,0 +1,21 @@
+# Example configuration file
+
+# Copy this file to config.py with your own values
+
+# Get this token by going to your Github profile settings and generating an
+# application key
+pccibottoken = 'CHANGEME'
+
+rooturl = 'http://localhost/'
+
+workers = 4
+
+logpath = '/tmp/logs'
+build_todo_aggressively = False
+
+
+commentable = ['puppetlabs/puppetlabs-stdlib',
+               'puppetlabs/puppetlabs-mysql']
+
+repos = ['puppetlabs/puppetlabs-stdlib',
+         'puppetlabs/puppetlabs-mysql']

--- a/follow_pull_requests.py
+++ b/follow_pull_requests.py
@@ -8,7 +8,8 @@ from github import Github
 from datetime import datetime, timedelta
 import config
 
-g = Github("puppet-community-ci", config.password)
+#g = Github(config.username, config.password)
+g = Github(config.pccibottoken)
 r = redis.StrictRedis(host='localhost', port=6379, db=0)
 
 


### PR DESCRIPTION
An example_config.py file is added to show users what a sample config
file looks like.

Additionally, the Github object already uses an application token in
comment.py, so let's use that again in follow_pull_requests and remove
the need for a username/password.