### PR TITLE
Add preliminary CentOS nodeset support for testing

### DIFF
--- a/example_config.py
+++ b/example_config.py
@@ -19,3 +19,35 @@ commentable = ['puppetlabs/puppetlabs-stdlib',
 
 repos = ['puppetlabs/puppetlabs-stdlib',
          'puppetlabs/puppetlabs-mysql']
+
+nodeset = {}
+nodeset['trusty'] = """
+HOSTS:
+  ubuntu-server-14041-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    user: 'vagrant'
+    password: 'vagrant'
+    hypervisor : libvirt
+    qcow2: '/home/pcci/sandbox/ubuntuvagrant.qcow2'
+    private_key_file: '/home/pcci/.vagrant_private.key'
+CONFIG:
+  type: foss
+"""
+
+nodeset['centos7'] = """
+HOSTS:
+  centos-7-1505-x86_64:
+    roles:
+      - master
+    platform: centos-7-1505-x86_64
+    user: 'vagrant'
+    password: 'vagrant'
+    hypervisor : libvirt
+    qcow2: '/home/pcci/sandbox/centosvagrant.qcow2'
+    private_key_file: '/home/pcci/.vagrant_private.key'
+CONFIG:
+  type: foss
+"""
+

--- a/follow_pull_requests.py
+++ b/follow_pull_requests.py
@@ -53,5 +53,8 @@ for repo in repos:
             stored_pull['merge_commit_sha'] = current_merge_commit_sha
             job = {}
             job['unique_name'] = unique_name
+            job['nodeset'] = 'trusty'
+            r.rpush('todo', json.dumps(job))
+            job['nodeset'] = 'centos7'
             r.rpush('todo', json.dumps(job))
         r.set(unique_name, json.dumps(stored_pull))


### PR DESCRIPTION
Moves the nodset definitions into a dict in the config file.
Adds a second work item for centos CI for every PR
Refactors the writing of nodeset file to get passed in with every call
of run_beaker_rspec