### PR TITLE
Move GitHub link to PR title column on module template

### DIFF
--- a/pcciweb.py
+++ b/pcciweb.py
@@ -88,6 +88,8 @@ def show_module_by_name(module_name):
     for i in range(completed_length):
         item = json.loads(r.lindex(module_name, i))
         # item = ('x', 'y')
+        pr_num = item['unique_name'].split('/')[2]
+        item['pr_num'] = pr_num  # We should probably do this in the backend.
         rev_completed.append(item)
 
     completed = rev_completed[::-1]

--- a/templates/module.html
+++ b/templates/module.html
@@ -5,12 +5,11 @@
 <h3>Completed Tests: {{ completed_length }}</h3>
 <table class="table table-hover">
   <tr>
-    <th>Module Name</th>
+    <th>Pull Request</th>
     <th>Success</th>
     <th>Seconds</th>
     <th>Nodeset</th>
     <th>Log</th>
-    <th>Github</th>
   </tr>
   {% for item in completed %}
   {% if item['response']['success'] == 0 %}
@@ -19,12 +18,11 @@
     {% set success=False %}
   {% endif %}
   <tr {% if not success %}class="danger"{% endif %}>
-    <td>{{ item.unique_name }}</td>
+    <td><a href='{{ item.github_url }}'>{{ "PR #" + item.pr_num }}</a></td>
     <td>{{ item.response.string_success }}</td>
     <td>{{ item.response.time }}</td>
     <td>{{ item.nodeset }}</td>
     <td><a href="http://ci.puppet.community/buildlogs/{{ item.log_path }}">Log</a></td>
-    <td><a href="{{ item.github_url}}">Github</a></td>
   </tr>
   {% endfor %}
 </table>


### PR DESCRIPTION
The old GitHub column was redundant. We should just link to the PR
from the title column.