### PR TITLE
Allow us to test each module against multiple nodesets

### DIFF
--- a/nodesets/centos7.yml
+++ b/nodesets/centos7.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-7-1505-x86_64:
+    roles:
+      - master
+    platform: centos-7-1505-x86_64
+    user: 'vagrant'
+    password: 'vagrant'
+    hypervisor : libvirt
+    qcow2: '/home/pcci/srv/centos7vagrant.qcow2'
+    private_key_file: '/home/pcci/.vagrant_private.key'
+CONFIG:
+  type: foss

--- a/nodesets/trusty.yml
+++ b/nodesets/trusty.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-server-14041-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    user: 'vagrant'
+    password: 'vagrant'
+    hypervisor : libvirt
+    qcow2: '/home/pcci/srv/trustyvagrant.qcow2'
+    private_key_file: '/home/pcci/.vagrant_private.key'
+CONFIG:
+  type: foss

--- a/run_test.py
+++ b/run_test.py
@@ -10,8 +10,8 @@ import subprocess
 import sys
 import tempfile
 import time
-
 import redis
+import yaml
 
 import config
 
@@ -74,8 +74,7 @@ def run_beaker_rspec(work_item, tempdir):
     print "Using libvirt nodeset: {0}".format(work_item['nodeset'])
 
     # Write out nodeset file
-    with open(jobdir + '/spec/acceptance/nodesets/libvirt.yml', 'w') as f:
-        f.write(config.nodeset[work_item['nodeset']])
+    shutil.copy('nodesets/' + work_item['nodeset'] + '.yml', jobdir + '/spec/acceptance/nodesets/libvirt.yml')
 
     # Run the test
     beaker = subprocess.Popen(["rspec", "spec/acceptance"],


### PR DESCRIPTION
Ideally this will pull the config from .pcci.yml file. If that doesn't
exist (which it doesn't right now) it will default to the current
behaviour of only testing ubuntu trusty and centos 7.

This also pulls out the nodeset definitions into proper yml files rather
that the current heredoc strings in pcci-configuration.

The intention of this PR is that it will allow us to explode the matrix
of possible test options.