### PR TITLE
templates: add platform icon display to completed.html

### DIFF
--- a/templates/completed.html
+++ b/templates/completed.html
@@ -7,6 +7,7 @@
     <th>&nbsp;</th>
     <th><span class="glyphicon glyphicon-open-file" aria-hidden="true"></span>&nbsp;&nbsp;Build Log</th>
     <th><span class="glyphicon glyphicon-tags" aria-hidden="true"></span>&nbsp;&nbsp;Commit SHA</th>
+    <th><span class="glyphicon" aria-hidden="true"></span>&nbsp;&nbsp;Platform</th>
     <th><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>&nbsp;&nbsp;Test Timestamp</th>
   </tr>
   {% for item in completed %}
@@ -22,6 +23,13 @@
     <td align='center'><span class="glyphicon {{ icon_class }}" aria-hidden="true" style="color: {{ icon_color }}; text-align: center;"></span></td>
     <td><a href="http://ci.puppet.community/buildlogs/{{ item['log_path'] }}" style="color: {{ icon_color }}">{{item['unique_name']}}</a></td>
     <td><a href="https://github.com/{{prlist[0]}}/{{prlist[1]}}/commit/{{item['pull']['merge_commit_sha']}}" style="color: {{ icon_color }}">{{item['pull']['merge_commit_sha']}}</a></td>
+    <td>{% if item.nodeset == "trusty" %}
+        {% set logo_img="ubuntu.logo.png" %}
+    {% else %}
+        {% set logo_img="centos.logo.png" %}
+    {% endif %}
+        <img src="{{ url_for('static', filename='img/' + logo_img)}}" height=20px; width=20px; alt={{ item.nodeset }}>
+    </td>
     <td>{{ item['pull']['begin_test'] }}</a></td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
This pull request adds a platform icon for each build with the alt text of a platform. This only adds display to completed.html. Modeled after the module.html usage.